### PR TITLE
Minor correction for continuation character. A $ was being used instead ...

### DIFF
--- a/src/esrubld/subsys.F
+++ b/src/esrubld/subsys.F
@@ -1783,7 +1783,7 @@ c --- 27-08-2014: Patrice Pinel: Added a parameter to the mechanical ventilation
           !CALL MECH_VENT_CONTROL(ICOMP,ZONE_mechvent_cond) ! Conductance of mech vent returned.
           CALL MECH_VENT_CONTROL(ICOMP,ZONE_mechvent_cond, 
      &                           ZONE_mechvent_moistFlow,
-     $                           ZONE_mechvent_airFlow)
+     &                           ZONE_mechvent_airFlow)
           CVIF = CVIF + ZONE_mechvent_cond
         ENDIF
 


### PR DESCRIPTION
...of &. Unsure if this makes a difference in computation, but syntax is now proper.