### PR TITLE
Enhancement to pass surface temps through co-simulator

### DIFF
--- a/src/co-sim/CosimShare.F
+++ b/src/co-sim/CosimShare.F
@@ -1,0 +1,49 @@
+C This file is part of the ESP-r system.
+C Copyright Carleton University 2011-2012.
+C Please Contact Ian Beausoliel-Morrison for details
+C concerning licensing.
+
+C ESP-r is free software.  You can redistribute it and/or
+C modify it under the terms of the GNU General Public
+C License as published by the Free Software Foundation
+C (version 2 or later).
+
+C ESP-r is distributed in the hope that it will be useful
+C but WITHOUT ANY WARRANTY; without even the implied
+C warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+C PURPOSE. See the GNU General Public License for more
+C details.
+
+C You should have received a copy of the GNU General Public
+C License along with ESP-r. If not, write to the Free
+C Software Foundation, Inc., 59 Temple Place, Suite 330,
+C Boston, MA 02111-1307 USA.
+
+C************************************************************************************
+C************************************************************************************
+C MODULE COSIMSHARE
+C *******************************************************************************
+C This module contains the following variables related to the
+C TRNSYS coupling component (TCC) in support of the co-simulation
+C between ESP-r and TRNSYS:
+C coSimNumSurf    The number of surface temperatures to be sent to TRNSYS from
+C                 ESP-r.
+C coSimZones      Array holding the zone numbers of the surfaces to be read
+C coSimSurfs      Array holding the surface numbers of the surfaces to be read
+C************************************************************************************
+C************************************************************************************
+      MODULE COSIMSHARE
+
+      IMPLICIT NONE
+      SAVE
+
+      INTEGER coSimNumSurf
+      ! Maximum surface temperatures that can be sent to the co-simulator
+      INTEGER, PARAMETER :: maxSend = 20      
+      INTEGER, DIMENSION(maxSend) :: coSimZones
+      INTEGER, DIMENSION(maxSend) :: coSimSurfs
+
+      END MODULE COSIMSHARE
+      
+C************************************************************************************
+C************************************************************************************      

--- a/src/co-sim/TCC.F
+++ b/src/co-sim/TCC.F
@@ -549,6 +549,7 @@ C ******************************************************************************
       INTEGER FUNCTION TCC_communication()
       USE DLL_Functions, ONLY:PassDataToTRNSYS,GetTRNSYSData,
      &                        GetSystemConv
+      USE COSIMSHARE
       IMPLICIT NONE
 #include "plant.h"
 #include "building.h"
@@ -588,13 +589,14 @@ C Common containing zone casual gains
 C Common saving coupled zones/surfaces
 
 C Number of Zones
-      integer ncomp,ncon
       common/c1/ncomp,ncon
+      integer ncomp,ncon
 
 C Zone air temperatures
-      real tpa,qpa,tfa,qfa
+      real tpa,qpa,tfa,qfa,tfs,qfs
       common/pvala/tpa(mcom),qpa(mcom)  !Zone air temperatures and heat transfers (present)
       common/fvala/tfa(mcom),qfa(mcom)  !Zone air temperatures and heat transfers (future)
+      common/fvals/tfs(mcom,ms),qfs(mcom) !Surfaces temperatures and heat transfers (future)
 C Humidity ratio (kg moisture/kg dry air) in zones.
       COMMON/FVALG/GFA(MCOM)
       REAL :: GFA
@@ -602,7 +604,7 @@ C Humidity ratio (kg moisture/kg dry air) in zones.
 C---------------------------------------------------------------------------------
 C Declare local variables.
 C---------------------------------------------------------------------------------
-      integer i ! count variable
+      integer i,k ! count variables
 
 
 C---------------------------------------------------------------------------------
@@ -616,9 +618,18 @@ C-------------------------------------------------------------------------------
 C---------------------------------------------------------------------------------
 C Prepare data from ESP-r's building thermal domain to pass to TRNSYS.
 C---------------------------------------------------------------------------------
-      DO i=1, ncomp
-        COSIM_DATA%ESPrZonesData(i)%AirPointTemperatures = TFA(i) ! Zone air-point temperature (oC).
-        COSIM_DATA%ESPrZonesData(i)%AirPointHumidities   = GFA(i) ! Zone air-point humidity (kgw/kga).
+      k=1 ! Reset indexer
+      DO i=1, (ncomp+coSimNumSurf)
+        IF(i<=ncomp)THEN
+            COSIM_DATA%ESPrZonesData(i)%AirPointTemperatures = TFA(i) ! Zone air-point temperature (oC).
+            COSIM_DATA%ESPrZonesData(i)%AirPointHumidities   = GFA(i) ! Zone air-point humidity (kgw/kga).
+        ELSE
+        ! Output extra surface temperatures if required
+        	COSIM_DATA%ESPrZonesData(i)%AirPointTemperatures = 
+     &                      TFS(coSimZones(k),coSimSurfs(k))                 	 
+        	COSIM_DATA%ESPrZonesData(i)%AirPointHumidities   = 0.0 ! Zone air-point humidity (kgw/kga).
+        	k=k+1 ! update indexer
+        END IF
       END DO
       
 

--- a/src/esruaco/Makefile
+++ b/src/esruaco/Makefile
@@ -13,6 +13,7 @@ MRTdir = $(SRCdir)/esrumrt
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG= aco$(EXE)
 default: $(PROG)
 
@@ -23,7 +24,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = aco.o acocalc.o acoesp.o arrow.o ascii_mat.o \
  	c2fdum.o common3dv.o CDBPlugins.o CDBCommon.o CDBExplore.o \
@@ -34,7 +35,7 @@ OBJECTS = aco.o acocalc.o acoesp.o arrow.o ascii_mat.o \
 	FMIcom.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o  $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS) $(F_to_C_flags)
@@ -66,6 +67,9 @@ CFC_Module.f90:
 common3dv.F:
 	rm -f common3dv.F
 	ln -s $(COMdir)/common3dv.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 cread3dv.F:
 	rm -f cread3dv.F
 	ln -s $(COMdir)/cread3dv.F .
@@ -165,7 +169,7 @@ clean:
 	emfnetw.F enetmisc.F enetrewr.F emkcfg.F eroper.F esru_misc.F esystem.F filelist.F \
 	inside.F item.F mfcdat.F nwkrewr.F pltcfg.F readTrnsys.F rwipv.F rwsbem.F \
 	sort.F startup.F tdfile.F h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrub2e/Makefile
+++ b/src/esrub2e/Makefile
@@ -12,6 +12,7 @@ MFSdir = $(SRCdir)/esrumfs
 PRJdir = $(SRCdir)/esruprj
 BLDdir = $(SRCdir)/esrubld
 CETCdir = $(SRCdir)/cetc
+COSIMdir = $(SRCdir)/co-sim
 PROG = b2e$(EXE)
 default: $(PROG)
 
@@ -22,7 +23,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = aim2_module.o startup.o
+MODULE_OBJECTS = aim2_module.o startup.o CosimShare.o
 
 OBJECTS = b2e.o CDBPlugins.o CDBCommon.o CDBExplore.o\
 	c2fdum.o clispline.o ctlwrt.o ctread.o daproc.o econtrol.o egeometry.o \
@@ -30,7 +31,8 @@ OBJECTS = b2e.o CDBPlugins.o CDBCommon.o CDBExplore.o\
 	nwkrewr.o pltcfg.o readTrnsys.o rwipv.o rwsbem.o simcomis.o sort.o tdfile.o \
 	FMIcom.o
 
-MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod parse_command_line.mod
+MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod parse_command_line.mod \
+          cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -50,6 +52,9 @@ CDBExplore.F:
 c2fdum.F:
 	rm -f c2fdum.F
 	ln -s $(COMdir)/c2fdum.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 ctlwrt.F:
 	rm -f ctlwrt.F
 	ln -s $(PRJdir)/ctlwrt.F .
@@ -129,7 +134,7 @@ clean:
 	c2fdum.F ctlwrt.F ctread.F econtrol.F egeometry.F emfnetw.F emkcfg.F esru_misc.F \
 	eroper.F esystem.F filelist.F initalc.F item.F mfcdat.F nwkrewr.F pltcfg.F sort.F startup.F tdfile.F \
 	readTrnsys.F rwipv.F rwsbem.F \
-	FMIcom.F
+	FMIcom.F CosimShare.F
 
 distclean: clean
 

--- a/src/esrubps/Makefile
+++ b/src/esrubps/Makefile
@@ -72,15 +72,15 @@ BPS_OBJECTS = bps.o adaptconf1.o adaptconf2.o adjb.o adjp.o ascii_mat.o \
 	  ncm_overheating.o CFC_opt_props.o CFC_thermal_and_aux.o editCFC.o NCHE.o stratified_tank_1HX.o stratified_tank_2HX.o \
 	  AirFlowModelRoutines.o Res_elec_Ctl.o harmonizer_timing.o qrun.o azalt.o
 
-PREBPS_OBJECTS = ESPrTrnsysData.o harmonizer_dummy.o
+PREBPS_OBJECTS = ESPrTrnsysData.o harmonizer_dummy.o CosimShare.o
 
 $(PROG): $(MODULE_OBJECTS) $(BPS_OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(BPS_OBJECTS) $(ULIBS) $(F_to_C_flags)
-PREBPSDLL_OBJECTS = ESPrTrnsysData.o harmonizer.o
+PREBPSDLL_OBJECTS = ESPrTrnsysData.o harmonizer.o CosimShare.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod aim2_timestep.mod \
 	parse_command_line.mod start_up.mod win32interface.mod dll_functions.mod tcc.mod cosimdatatypes.mod \
-	h3kmodule.mod CFC_Module.mod
+	h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 ifeq ($(FMIarg),enableFMI)
 	FMI_OBJECTS = FMIsim.o FMIcom.o FMIc.o
@@ -209,6 +209,9 @@ convect1.F:
 convect2.F:
 	rm -f convect2.F
 	ln -s $(BLDdir)/convect2.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 ctread.F:
 	rm -f ctread.F
 	ln -s $(COMdir)/ctread.F .
@@ -813,7 +816,7 @@ clean:
 	tank_intank_hx.F mains_temp_draw_profiles.F stratified_tank.F \
 	FMIsim.F FMIc.c FMIsim_dummy.F FMIcom.F \
 	CFC_opt_props.F CFC_thermal_and_aux.F editCFC.F NCHE.F stratified_tank_1HX.F stratified_tank_2HX.F \
-	AirFlowModelRoutines.F Res_elec_Ctl.F h3kmodule.f90 qrun.F azalt.F CFC_Module.f90
+	AirFlowModelRoutines.F Res_elec_Ctl.F h3kmodule.f90 qrun.F azalt.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrucnv/Makefile
+++ b/src/esrucnv/Makefile
@@ -12,6 +12,7 @@ MFSdir = $(SRCdir)/esrumfs
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG = ecnv$(EXE)
 default: $(PROG)
 
@@ -22,7 +23,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = ecnv.o ascii_mat.o c2fdum.o ctread.o \
 	  CDBPlugins.o CDBCommon.o CDBExplore.o dossupport.o \
@@ -34,7 +35,7 @@ OBJECTS = ecnv.o ascii_mat.o c2fdum.o ctread.o \
 	  FMIcom.o
       
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -60,6 +61,9 @@ c2fdum.F:
 CFC_Module.f90:
 	rm -f CFC_Module.f90
 	ln -s $(BLDdir)/CFC_Module.f90 .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 ctread.F:
 	rm -f ctread.F
 	ln -s $(COMdir)/ctread.F .
@@ -149,7 +153,7 @@ clean:
 	emfnetw.F emkcfg.F enetmisc.F enetrewr.F eroper.F esru_misc.F esystem.F \
 	filelist.F item.F mfcdat.F nwkrewr.F pltcfg.F readTrnsys.F rwipv.F rwsbem.F \
 	sort.F startup.F tdfile.F h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrucom/pltcfg.F
+++ b/src/esrucom/pltcfg.F
@@ -137,6 +137,7 @@ C  iunit1 is the unit number of the plant database (this is opened
 C      within the subroutine).
 C  itu is the output channel for reporting (if itrc is > zero).
 C  itrc the level of reporting (zero is quiet).
+      USE COSIMSHARE
 
 #include "plant.h"
 #include "building.h"
@@ -205,6 +206,7 @@ C containing NMISC.
       integer lndbp   ! for length of standard database path
       integer ier
       logical unixok
+      integer counter ! Generic loop counter
 
 C Set folder separator (fs) to \ or / as required.
       call isunix(unixok)
@@ -916,6 +918,33 @@ C Also change over flow connection.
               endif   
            endif
  709    continue
+
+C Determine if there are additional surface temperatures to be sent to 
+C the co-simulator
+        CALL STRIPC(iuc,OUTSTR,0,counter,1,'co-sim surfaces',IER)
+        IF(IER.NE.0)RETURN
+        K=0
+        CALL EGETWI(OUTSTR,K,coSimNumSurf,0,maxSend,'W',
+     &        'co-sim surfaces',IER)
+        IF(coSimNumSurf<0) coSimNumSurf=0 ! Number of surfaces cannot be less then zero
+        
+        if(coSimNumSurf > 0) then
+        	! There are surface temperatures to be reported to the 
+        	! Co-simulator.
+        	! Move to next line and collect surface indexes
+        	CALL STRIPC(iuc,OUTSTR,0,counter,1,'co-sim indexes',IER)
+            IF(IER.NE.0)RETURN
+            K=0
+        	! Begin pulling zone and surface indexes from input
+        	do  counter=1,coSimNumSurf
+  				CALL EGETWI(OUTSTR,K,coSimZones(counter),0,ncomp,'W',
+     &           'co-sim zone ind',IER) ! Zone number
+  	            IF(IER.NE.0)RETURN
+  	            CALL EGETWI(OUTSTR,K,coSimSurfs(counter),0,
+     &           MS,'W','co-sim surf ind',IER) ! Surface number
+  	            IF(IER.NE.0) RETURN 
+  			end  do
+        endif
 
 C Close plant cfg file before exiting.
     6   CALL ERPFREE(IUC,ISTAT)

--- a/src/esrudbm/Makefile
+++ b/src/esrudbm/Makefile
@@ -12,6 +12,7 @@ MFSdir = $(SRCdir)/esrumfs
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG = dbm$(EXE)
 default: $(PROG)
 
@@ -23,7 +24,7 @@ default: $(PROG)
 	$(MCC) $(FFLAGS) -c $<
 
 
-MODULE_OBJECTS = h3kmodule.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = jdbm.o ascii_mat.o basesimp.o basesimp_inputs.o bscoeff.o bscoeff_extended.o \
 	bcffile.o c2fdum.o ctlexp.o ctread.o dbmedit.o dossupport.o edprof.o \
@@ -36,7 +37,7 @@ OBJECTS = jdbm.o ascii_mat.o basesimp.o basesimp_inputs.o bscoeff.o bscoeff_exte
 
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod \
-          h3kmodule.mod CFC_Module.mod
+          h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG) : $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(FFLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -74,6 +75,9 @@ CFC_Module.f90:
 c2fdum.F:
 	rm -f c2fdum.F
 	ln -s $(COMdir)/c2fdum.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 ctlexp.F:
 	rm -f ctlexp.F
 	ln -s $(COMdir)/ctlexp.F .
@@ -145,7 +149,7 @@ clean :
 	c2fdum.F ctlexp.F ctread.F dossupport.F edatabase.F \
 	egeometry.F emfnetw.F emkcfgg.F eroper.F esru_misc.F filelist.F item.F mfcdat.F nwkrewr.F \
 	pltcfg.F sort.F tdfile.F readTrnsys.F h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrue2r/Makefile
+++ b/src/esrue2r/Makefile
@@ -13,6 +13,7 @@ MRTdir = $(SRCdir)/esrumrt
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG = e2r$(EXE)
 default: $(PROG)
 
@@ -23,7 +24,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = e2r.o arrow.o ascii_mat.o c2fdum.o common3dv.o cread3dv.o \
 	  ctlexp.o ctread.o CDBPlugins.o CDBCommon.o CDBExplore.o\
@@ -35,7 +36,7 @@ OBJECTS = e2r.o arrow.o ascii_mat.o c2fdum.o common3dv.o cread3dv.o \
 	  FMIcom.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -64,6 +65,9 @@ c2fdum.F:
 common3dv.F:
 	rm -f common3dv.F
 	ln -s $(COMdir)/common3dv.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 CFC_Module.f90:
 	rm -f CFC_Module.f90
 	ln -s $(BLDdir)/CFC_Module.f90 .
@@ -175,7 +179,7 @@ clean:
 	emfnetw.F enetmisc.F eroper.F esru_misc.F esystem.F filelist.F inside.F item.F mfcdat.F \
 	nwkrewr.F plelevvc.F pltcfg.F readTrnsys.F rwipv.F rwsbem.F  sort.F startup.F tdfile.F \
         h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrueco/Makefile
+++ b/src/esrueco/Makefile
@@ -13,6 +13,7 @@ MRTdir = $(SRCdir)/esrumrt
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG= eco$(EXE)
 default: $(PROG)
 
@@ -23,7 +24,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = eco.o arrow.o ascii_mat.o c2fdum.o common3dv.o cread3dv.o \
 	  CDBPlugins.o CDBCommon.o CDBExplore.o \
@@ -35,7 +36,7 @@ OBJECTS = eco.o arrow.o ascii_mat.o c2fdum.o common3dv.o cread3dv.o \
 	  FMIcom.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o  $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -67,6 +68,9 @@ CFC_Module.f90:
 common3dv.F:
 	rm -f common3dv.F
 	ln -s $(COMdir)/common3dv.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 cread3dv.F:
 	rm -f cread3dv.F
 	ln -s $(COMdir)/cread3dv.F .
@@ -171,7 +175,7 @@ clean:
 	filelist.F esystem.F inside.F item.F mfcdat.F nwkrewr.F \
 	pltcfg.F readTrnsys.F rwipv.F rwsbem.F sort.F startup.F tdfile.F \
 	h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrugrd/Makefile
+++ b/src/esrugrd/Makefile
@@ -12,6 +12,7 @@ MFSdir = $(SRCdir)/esrumfs
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG = grd$(EXE)
 default: $(PROG)
 
@@ -22,7 +23,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = grd.o arrow.o ascii_mat.o bgrd1d.o bgrd1m.o bgrd3d.o bgrdst.o c2fdum.o \
 	 common3dv.o CDBPlugins.o CDBCommon.o CDBExplore.o\
@@ -34,7 +35,7 @@ OBJECTS = grd.o arrow.o ascii_mat.o bgrd1d.o bgrd1m.o bgrd3d.o bgrdst.o c2fdum.o
 	 FMIcom.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -66,6 +67,9 @@ CFC_Module.f90:
 common3dv.F:
 	rm -f common3dv.F
 	ln -s $(COMdir)/common3dv.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 cread3dv.F:
 	rm -f cread3dv.F
 	ln -s $(COMdir)/cread3dv.F .
@@ -174,7 +178,7 @@ clean:
 	enetmisc.F enetrewr.F emkcfg.F emoist.F esgrid.F eroper.F esru_misc.F \
 	esystem.F filelist.F item.F mfcdat.F nwkrewr.F pltcfg.F rwipv.F rwsbem.F sort.F \
 	startup.F tdfile.F trnsf.F readTrnsys.F h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esruish/Makefile
+++ b/src/esruish/Makefile
@@ -12,6 +12,7 @@ MFSdir = $(SRCdir)/esrumfs
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG = ish$(EXE)
 default: $(PROG)
 
@@ -22,7 +23,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = ish.o arrow.o ascii_mat.o CDBPlugins.o CDBCommon.o CDBExplore.o \
 	c2fdum.o common3dv.o cread3dv.o ctlexp.o ctread.o dossupport.o \
@@ -34,7 +35,7 @@ OBJECTS = ish.o arrow.o ascii_mat.o CDBPlugins.o CDBCommon.o CDBExplore.o \
 	FMIcom.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -66,6 +67,9 @@ CFC_Module.f90:
 common3dv.F:
 	rm -f common3dv.F
 	ln -s $(COMdir)/common3dv.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 cread3dv.F:
 	rm -f cread3dv.F
 	ln -s $(COMdir)/cread3dv.F .
@@ -165,7 +169,7 @@ clean:
 	egeometry.F emfnetw.F enetmisc.F enetrewr.F esru_misc.F esystem.F \
 	eroper.F filelist.F item.F mfcdat.F nwkrewr.F plelevvc.F readTrnsys.F rwipv.F \
 	rwsbem.F sort.F startup.F tdfile.F pltcfg.F h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrumrt/Makefile
+++ b/src/esrumrt/Makefile
@@ -12,6 +12,7 @@ MFSdir = $(SRCdir)/esrumfs
 PRJdir = $(SRCdir)/esruprj
 CETCdir = $(SRCdir)/cetc
 BLDdir = $(SRCdir)/esrubld
+COSIMdir = $(SRCdir)/co-sim
 PROG = mrt$(EXE)
 PROG2 = espvwf$(EXE)
 default: $(PROG)
@@ -23,7 +24,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = espvwf.o arrow.o ascii_mat.o bound.o bubble.o c2fdum.o checkrec.o \
 	  common3dv.o CDBPlugins.o CDBCommon.o CDBExplore.o cread3dv.o \
@@ -35,7 +36,7 @@ OBJECTS = espvwf.o arrow.o ascii_mat.o bound.o bubble.o c2fdum.o checkrec.o \
 	  FMIcom.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -67,6 +68,9 @@ CFC_Module.f90:
 common3dv.F:
 	rm -f common3dv.F
 	ln -s $(COMdir)/common3dv.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 cread3dv.F:
 	rm -f cread3dv.F
 	ln -s $(COMdir)/cread3dv.F .
@@ -163,7 +167,7 @@ clean:
 	eroper.F esru_misc.F esystem.F filelist.F item.F mfcdat.F nwkrewr.F \
 	plelevvc.F pltcfg.F readTrnsys.F rwipv.F rwsbem.F sort.F startup.F tdfile.F \
 	h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrupdf/cfgmsc.F
+++ b/src/esrupdf/cfgmsc.F
@@ -26,6 +26,8 @@ C*********************** pcwrt ************************
 C This subroutine writes plant network data to configuration
 C file.
       subroutine pcwrt
+
+      USE COSIMSHARE
 #include "plant.h"
 #include "building.h"
 
@@ -240,6 +242,25 @@ C Write out max 6 items per line. << todo - use names >>
  1011    format(12(6(I4,1x),/))
          if(amod(float(icffs(jj)),6.0).eq.0.0) backspace IFPNF
       endif
+C Write co-simulation surface indices
+      if(coSimNumSurf<=0) then
+         write(IFPNF,'(a)')
+     &     '# No additional co-sim surfaces defined.'
+         write(IFPNF,'(I5)') coSimNumSurf
+      else
+         write(IFPNF,'(a)')
+     &     '# Additional surface temps to be sent to TRNSYS.'
+         write(IFPNF,'(I5)') coSimNumSurf
+         do 42 icont=1, coSimNumSurf
+         	 ! Write zone number 
+             write(IFPNF,'(I5)',advance='no') coSimZones(icont)
+     
+             ! Write surface number
+             write(IFPNF,'(I5)',advance='no') coSimSurfs(icont)
+
+ 42   continue
+         
+      endif      
       close(IFPNF)
       return
       end

--- a/src/esrupdf/newnet.F
+++ b/src/esrupdf/newnet.F
@@ -37,6 +37,7 @@ C    CONTLYR allows the user to select a layer in a construction
 C    SCANBPLINK: scans a control file for building plant linkages
 C    ASKBPLINK: presents a list of plant components returning the index IS.
 C    EDBPLINK: allows building plant link  to be added, deleted or edited.
+C    COSIMLINK: sets up the surface temperature linkage between ESP-r and TRNSYS
 
 C*********************** newnet ************************
 C Newnet displays menu for defining plant components,
@@ -46,6 +47,7 @@ C     simtyp - holds description of simulation type.
 
       subroutine newnet(iedit,mode)
 
+      USE COSIMSHARE
 #include "plant.h"
 #include "building.h"
 #include "control.h"      
@@ -104,7 +106,7 @@ C Common controlling format of plant network file
       character lpnam*72,laprob*72,LPNF*72
 
       dimension ival(mpcom)
-      CHARACTER*44 ITEM(28)
+      CHARACTER*44 ITEM(31)
       CHARACTER H*72,outs*124,ltmp*72,pcname*15, lctlf*72,ctldoc*248
       CHARACTER ICDIR*72, DOIT*248,mode*1,pcdesc*80
       character*68 mscdsc, cvrdsc,hfpdsc
@@ -186,7 +188,10 @@ C Read components data from database
       endif
 
 C First initialise all variables.
-      if(iedit.ne.1) call initiv(ipcomp) 
+      if(iedit.ne.1) then
+          call initiv(ipcomp)
+          coSimNumSurf=0
+      endif
 
 C Let user select the simulation type required.
       if (npmtyp.eq.0) then
@@ -243,10 +248,14 @@ C Let the user pick a menu item.
         item(24)='j plant config file format > short'
       endif
       item(25)='  ---------------------    '
-      item(26)='! Update plant config file '
-      item(27)='? Help                     '
-      item(28)='- Exit                     '
-      nitms=28
+      write(item(26),
+     &'(a,i3,a)')'No. of linked co-sim surfaces... ( ',coSimNumSurf,' )'      
+      item(27)='k Link surfaces to co-simulation '
+      item(28)='  ---------------------    '
+      item(29)='! Update plant config file '
+      item(30)='? Help                     '
+      item(31)='- Exit                     '
+      nitms=31
 
 C If newnet is called with mode 'G' skip menu definition.
       if(mode.eq.'G') then
@@ -464,8 +473,12 @@ C Toggle .pln file format
           bPLN_format_long = .false.
         else
           bPLN_format_long = .true.
-        endif  
-        
+        endif
+
+C Link surfaces to the co-simulator
+      elseif(ino.eq.27) then
+         CALL COSIMLINK        
+
       elseif(ino.eq.nitms-2) then
 
 C Overwrite the existing plant configuration file
@@ -2863,3 +2876,38 @@ C Update the zone -> control linkages
       RETURN      
       END
 
+C ************************** COSIMLINK *******************************8
+C COSIMLINK allows building plant link  to be added, deleted or edited.
+C The function is determined by the mode:
+C E - edit
+C A - add
+C D - delete
+
+      SUBROUTINE COSIMLINK
+      
+      USE COSIMSHARE
+#include "building.h"      
+      
+C     Number of Zones
+      common/c1/ncomp,ncon
+      integer ncomp,ncon
+      
+C     Local variables      
+      CHARACTER HOLD*72,MSG*70
+      INTEGER IER	! Holds error code
+      INTEGER i 	! Generic counter
+      
+      CALL EASKI(coSimNumSurf,' ','How many surfaces to be connected?',
+     &                    0,'F',maxSend,'F',0,'co-sim surf cons',IER,0)
+     
+      DO 682 i=1,coSimNumSurf
+        WRITE( MSG,'(A4,I3)') 'Surf',i
+      	CALL EASKI(coSimZones(i),MSG,'Zone Index?',
+     &                    1,'F',ncomp,'F',1,'cosim zones',IER,0)
+        CALL EASKI(coSimSurfs(i),MSG,'Surf Index?',
+     &                    1,'F',MS,'F',6,'cosim surfs',IER,0)
+            
+ 682  CONTINUE
+      
+      RETURN
+      END

--- a/src/esruplt/pcomps.F
+++ b/src/esruplt/pcomps.F
@@ -125,6 +125,7 @@ C CMP??C coefficient generator routine
       SUBROUTINE MZSDAT
       USE TCC, ONLY:TCC_static, HCC, ACC, InitializeCosimDataTypes
       USE DLL_Functions, ONLY:SetArraySizes
+      USE COSIMSHARE
 #include "plant.h"
 
       COMMON/OUTIN/IUOUT,IUIN
@@ -405,7 +406,7 @@ C zones in the model.
       Sizes(2) = HCC_R-1
       Sizes(3) = ACC_S-1
       Sizes(4) = ACC_R-1
-      Sizes(5) = nComp
+      Sizes(5) = nComp+coSimNumSurf
       call SetArraySizes(Sizes)
 
       RETURN

--- a/src/esruprj/Makefile
+++ b/src/esruprj/Makefile
@@ -14,6 +14,7 @@ PDFdir = $(SRCdir)/esrupdf
 VLDdir = $(SRCdir)/esruvld
 PLTdir = $(SRCdir)/esruplt
 CETCdir = $(SRCdir)/cetc
+COSIMdir = $(SRCdir)/co-sim
 INCLdir = $(SRCdir)/include
 PROG = prj$(EXE)
 default: $(PROG)
@@ -25,7 +26,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o aim2_inputs.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o aim2_inputs.o CFC_Module.o CosimShare.o
 
 OBJECTS = prj.o anlytc.o arrow.o ascii_mat.o basesimp.o \
 	  basesimp_inputs.o blcond.o bnlthp.o bpfcom.o bpfcontrl.o bscoeff.o bscoeff_extended.o \
@@ -50,7 +51,7 @@ OBJECTS = prj.o anlytc.o arrow.o ascii_mat.o basesimp.o \
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod aim2_inputs.mod \
 	  aim2_inputs_inputdata.mod start_up.mod parse_command_line.mod h3kmodule.mod \
-      CFC_Module.mod
+      CFC_Module.mod cosimshare.mod
 
 ifeq ($(FMIarg),enableFMI)
 	FMI_OBJECTS = FMIcom.o FMIprj.o
@@ -120,6 +121,9 @@ common3dv.F:
 commonclm.F:
 	rm -f commonclm.F
 	ln -s $(COMdir)/commonclm.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 ctlexp.F:
 	rm -f ctlexp.F
 	ln -s $(COMdir)/ctlexp.F .
@@ -308,7 +312,7 @@ clean:
 	hvacinput.F item.F mcdbscn.F mfcdat.F mfelst.F mfnmsc.F mfrlst.F MultiYear_climate.F mvalid.F \
 	net2pdf.F newnet.F nwkrewr.F plelevvc.F pltcfg.F psychro.F rcdblist.F rwipv.F rwroam.F \
 	rwsbem.F senrwl.F sort.F spmisc.F stndrds.F startup.F tdfile.F  \
-	readTrnsys.F PltDummy.F qrun.F h3kmodule.f90 FMIcom.F CFC_Module.f90
+	readTrnsys.F PltDummy.F qrun.F h3kmodule.f90 FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 

--- a/src/esrures/Makefile
+++ b/src/esrures/Makefile
@@ -13,6 +13,7 @@ MFSdir = $(SRCdir)/esrumfs
 PRJdir = $(SRCdir)/esruprj
 BLDdir = $(SRCdir)/esrubld
 CETCdir = $(SRCdir)/cetc
+COSIMdir = $(SRCdir)/co-sim
 PROG = res$(EXE)
 REPdir = $(SRCdir)/cetc/h3kreports
 default: $(PROG)
@@ -23,7 +24,7 @@ default: $(PROG)
 %.o : %.f90
 	$(MCC) $(FFLAGS) -c $<
 
-MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o
+MODULE_OBJECTS = h3kmodule.o startup.o aim2_module.o CFC_Module.o CosimShare.o
 
 OBJECTS = res.o arrow.o ascii_mat.o c2fdum.o castyp.o cfdat.o cfgrid.o cfutil.o cgd.o \
 	  comfort.o convect2.o ctread.o design.o dmdrep.o dossupport.o e3dviews.o \
@@ -40,7 +41,7 @@ OBJECTS = res.o arrow.o ascii_mat.o c2fdum.o castyp.o cfdat.o cfgrid.o cfutil.o 
 	  FMIcom.o
 
 MODULES = aim2.mod aim2_calcdata.mod aim2_h2k_dummy.mod aim2_inputdata.mod start_up.mod \
-	parse_command_line.mod h3kmodule.mod CFC_Module.mod
+	parse_command_line.mod h3kmodule.mod CFC_Module.mod cosimshare.mod
 
 $(PROG): $(MODULE_OBJECTS) $(OBJECTS)
 	$(MFC) $(LD_FLAGS) -o $(PROG) $(FFLAGS) $(MODULE_OBJECTS) $(OBJECTS) $(ULIBS)
@@ -81,6 +82,9 @@ cgd.F:
 convect2.F:
 	rm -f convect2.F
 	ln -s $(BLDdir)/convect2.F .
+CosimShare.F:
+	rm -f CosimShare.F
+	ln -s $(COSIMdir)/CosimShare.F .
 ctread.F:
 	rm -f ctread.F
 	ln -s $(COMdir)/ctread.F .
@@ -205,7 +209,7 @@ clean:
 	esystem.F filelist.F fanger.F initalc.F item.F mfcdat.F mfutil.F nwkrewr.F pltcfg.F \
 	psychro.F readTrnsys.F rwipv.F rwsbem.F sort.F spmatl.F spmisc.F startup.F tdfile.F \
 	visgrd.F visual.F visvec.F h3kmodule.f90 \
-	FMIcom.F CFC_Module.f90
+	FMIcom.F CFC_Module.f90 CosimShare.F
 
 distclean: clean
 


### PR DESCRIPTION
This commit adds functionality to the ESP-r/TRNSYS co-simulator. Specified
internal zone surfaces may now send their temperature data to TRNSYS at
each timestep. This hack uses a similar approach introduced on
Sebastien_Brideau branch @r9363 with a key differences; an extra,
artificial zone is not required.

Instead, the user specifies the number of additional surface temperatures
to be read into TRNSYS as well as their zone and surface indexes at the
bottom of the plant network file.

Additionally the may user can use the explicit plant network menu in prj
to define how many and which internal surface temperatures in the model to
send to TRNSYS via the harmonizer.

Testing summary:
- Successfully compiled X11 version on Windows XP/Cygwin (GCC 4.5.3).
- Successfully compiled GTK version on Windows XP.
- Successfully compiled and co-simulated with bps.dll
- Compared surface temperatures received by TRNSYS and the h3k output
- Opened a pre-configured .pln file with co-simulation surface linkage
  defined.
- Created a .pln file with no co-simulation surface linkages defined
  using the plant network menu items.
- Created a .pln file with co-simulation surface linkages defined
  using the plant network menu items.