### PR TITLE
Change to BASESIMP Model input checking

### DIFF
--- a/src/esrubld/basesimp.F
+++ b/src/esrubld/basesimp.F
@@ -193,7 +193,7 @@ c-----BASESIMP foundations allow widths from 1 to 20 m and lengths from 1 to 100
         fMaxWaterTable = 15.0   ! meter
       ENDIF
 
-      CALL EGETWR(OUTSTR,K,VAL,1.0,2.5,'F',' basement height',IER)
+      CALL EGETWR(OUTSTR,K,VAL,1.0,2.5,'W',' basement height',IER)
       if(IER.NE.0)then
         t60='Cannot read height of foundation or out of range'
         goto 1000
@@ -204,7 +204,7 @@ C Read foundation depth.
       CALL STRIPC(IUNIT,OUTSTR,1,ND,1,' BASESIMP data',IER)
       IF(IER.NE.0)goto 1000
       K=0
-      CALL EGETWR(OUTSTR,K,VAL,0.05,2.4,'F',' found. depth',IER)
+      CALL EGETWR(OUTSTR,K,VAL,0.05,2.4,'W',' found. depth',IER)
       if(IER.NE.0)then
         t60='Cannot read depth of foundation or of range '
         goto 1000
@@ -227,7 +227,7 @@ C Read foundation length.
       IF(IER.NE.0)goto 1000
       K=0
       CALL EGETWR(OUTSTR,K,VAL,fMinFoundLength,fMaxFoundLength,
-     &            'F',' found. length',IER)
+     &            'W',' found. length',IER)
       if(IER.NE.0)then
         t60='Cannot read length of foundation or out of range '
         goto 1000
@@ -239,7 +239,7 @@ C Read foundation width.
       IF(IER.NE.0)goto 1000
       K=0
       CALL EGETWR(OUTSTR,K,VAL,fMinFoundWidth,fMaxFoundWidth,
-     &            'F',' found. width',IER)
+     &            'W',' found. width',IER)
       if(IER.NE.0)then
         t60='Cannot read width of foundation or out of range '
         goto 1000
@@ -257,7 +257,7 @@ C present, but only used for combination cases, eg. BCCN_1 and BCCN_2.
       CALL STRIPC(IUNIT,OUTSTR,1,ND,1,' BASESIMP data',IER)
       IF(IER.NE.0)goto 1000
       K=0
-      CALL EGETWR(OUTSTR,K,VAL,0.,2.4,'F',' overlap',IER)
+      CALL EGETWR(OUTSTR,K,VAL,0.,2.4,'W',' overlap',IER)
       if(IER.NE.0)then
         t60='Cannot read inside/outside overlap or out of range '
         goto 1000

--- a/src/esruprj/basesimp_inputs.F
+++ b/src/esruprj/basesimp_inputs.F
@@ -325,35 +325,35 @@ C CONTENT for depth of basement.
       min_bsmtDepth = 0.05                    ! meter
       max_bsmtDepth = 2.4                     ! meter
       CALL EASKR(bsmtDepth,' ',' Depth of the basement (m) ? ',
-     &  min_bsmtDepth,'F',max_bsmtDepth,'F',bsmtDepth,
+     &  min_bsmtDepth,'F',max_bsmtDepth,'W',bsmtDepth,
      & 'depth of the basement',IER,nbhelp)
 
 C CONTENT for height of basement.
       min_bsmtHeight = bsmtDepth+0.1          ! meter
       max_bsmtHeight = 2.5                    ! meter
       CALL EASKR(bsmtHeight,' ',' Height of the basement (m) ? ',
-     &  min_bsmtHeight,'F',max_bsmtHeight,'F',bsmtHeight,
+     &  min_bsmtHeight,'F',max_bsmtHeight,'W',bsmtHeight,
      &  'height of the basement',IER,nbhelp)
 
 C CONTENT for width of basement.
       min_bsmtWidth = 2.                      ! meter
       max_bsmtWidth = 20.                     ! meter
       CALL EASKR(bsmtWidth,' ',' Width of the basement (m) ? ',
-     &  min_bsmtWidth,'F',max_bsmtWidth,'F',bsmtWidth,
+     &  min_bsmtWidth,'F',max_bsmtWidth,'W',bsmtWidth,
      &  'width of the basement',IER,nbhelp)
 
 C CONTENT for length of basement.
       min_bsmtLength = bsmtWidth              ! meter
       max_bsmtLength = 20.                    ! meter
       CALL EASKR(bsmtLength,' ',' Length of the basement (m) ? ',
-     &  min_bsmtLength,'F',max_bsmtLength,'F',bsmtLength,
+     &  min_bsmtLength,'F',max_bsmtLength,'W',bsmtLength,
      &  'width of the basement',IER,nbhelp)
 
 C CONTENT for insulation overlap.
       min_Insul_Overlap = 0.                  ! meter
       max_Insul_Overlap = 2.4                 ! meter
       CALL EASKR(Insul_Overlap,' ',' Insulation overlap (m)? ',
-     &  min_Insul_Overlap,'F',max_Insul_Overlap,'F',Insul_Overlap,
+     &  min_Insul_Overlap,'F',max_Insul_Overlap,'W',Insul_Overlap,
      &  'Insulation overlap',IER,nbhelp)
 
 C CONTENT for insulation RSI.


### PR DESCRIPTION
Read in of BASESIMP inputs has been modified so that when dimensional inputs exceed
the limits, a warning rather than a fatal error is thrown. This was done to facilitate
the modelling of larger basements, but it is acknowledged exceeding these bounds exceeds
the domain of the regression used to create BASESIMP.